### PR TITLE
refactor(client): UI reorg, font fix, and reusable API utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
         "drizzle-orm": "^0.32.1",
         "next": "^14.2.19",
         "postgres": "^3.4.4",
+        "query-string": "^9.1.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "use-debounce": "^10.0.4"
       },
       "devDependencies": {
         "@types/node": "^20.14.12",
@@ -2019,6 +2021,14 @@
         }
       }
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2977,6 +2987,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-up": {
@@ -4683,6 +4704,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/query-string": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.1.1.tgz",
+      "integrity": "sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==",
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5069,6 +5106,17 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stable-hash": {
@@ -5622,6 +5670,17 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-debounce": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.4.tgz",
+      "integrity": "sha512-6Cf7Yr7Wk7Kdv77nnJMf6de4HuDE4dTxKij+RqE9rufDsI6zsbjyAxcH5y2ueJCQAnfgKbzXbZHYlkFwmBlWkw==",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "drizzle-orm": "^0.32.1",
     "next": "^14.2.19",
     "postgres": "^3.4.4",
+    "query-string": "^9.1.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "use-debounce": "^10.0.4"
   },
   "devDependencies": {
     "@types/node": "^20.14.12",

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -2,7 +2,7 @@ import db from "@/db"
 import { advocates } from "@/db/schema"
 import { sql } from "drizzle-orm"
 import { NextRequest, NextResponse } from "next/server"
-import { generateSearchWhereClause } from "./utils"
+import { generateAdvocatesWhereClause } from "./utils"
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
   const offset = Number(searchParams.get("offset")) || 0
   const searchQuery = searchParams.get("searchQuery")?.toLowerCase() ?? ""
 
-  const whereClause = generateSearchWhereClause(searchQuery)
+  const whereClause = generateAdvocatesWhereClause(searchQuery)
 
   const paginatedAdvocates = await db
     .select()

--- a/src/app/api/advocates/utils.ts
+++ b/src/app/api/advocates/utils.ts
@@ -1,7 +1,8 @@
 import { advocates } from "@/db/schema"
 import { ilike, or, sql } from "drizzle-orm"
+import { apiFetch } from "../apiUtils/apiFetch"
 
-export const generateSearchWhereClause = (searchQuery: string | null) => {
+export const generateAdvocatesWhereClause = (searchQuery: string | null) => {
   return searchQuery
     ? or(
         ilike(advocates.firstName, `%${searchQuery}%`),
@@ -16,4 +17,9 @@ export const generateSearchWhereClause = (searchQuery: string | null) => {
         }`
       )
     : undefined
+}
+
+export const getAdvocates = async (url: string) => {
+  const response = await apiFetch(url)
+  return response
 }

--- a/src/app/api/apiUtils/apiFetch.ts
+++ b/src/app/api/apiUtils/apiFetch.ts
@@ -1,0 +1,8 @@
+const isServer = typeof window === "undefined"
+const baseUrl = isServer ? process.env.NEXT_PUBLIC_SITE_URL : ""
+
+export const apiFetch = async (url: string) => {
+  const fullUrl = `${baseUrl}${url}`
+  const response = await fetch(fullUrl)
+  return response.json()
+}

--- a/src/app/api/apiUtils/getApiUrl.ts
+++ b/src/app/api/apiUtils/getApiUrl.ts
@@ -1,0 +1,7 @@
+import queryString from "query-string"
+
+type QueryParams = Record<string, string | number | boolean | null | undefined>
+
+export const getApiUrl = (baseUrl: string, queryParams?: QueryParams) => {
+  return queryString.stringifyUrl({ url: baseUrl, query: queryParams })
+}

--- a/src/app/components/AdvocatesTable.tsx
+++ b/src/app/components/AdvocatesTable.tsx
@@ -1,0 +1,43 @@
+import { memo } from "react"
+import { Advocate } from "../types/advocates"
+
+type AdvocatesTableProps = {
+  advocates: Advocate[]
+}
+
+export const AdvocatesTable = memo(({ advocates }: AdvocatesTableProps) => {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>City</th>
+          <th>Degree</th>
+          <th>Specialties</th>
+          <th>Years of Experience</th>
+          <th>Phone Number</th>
+        </tr>
+      </thead>
+      <tbody>
+        {advocates.map((advocate) => {
+          return (
+            <tr key={advocate.id}>
+              <td>{advocate.firstName}</td>
+              <td>{advocate.lastName}</td>
+              <td>{advocate.city}</td>
+              <td>{advocate.degree}</td>
+              <td>
+                {advocate.specialties.map((s) => (
+                  <div key={s}>{s}</div>
+                ))}
+              </td>
+              <td>{advocate.yearsOfExperience}</td>
+              <td>{advocate.phoneNumber}</td>
+            </tr>
+          )
+        })}
+      </tbody>
+    </table>
+  )
+})

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import url("https://fonts.googleapis.com/css2?family=Inter&display=swap");
+
+:root {
+  --font-sans: "Inter", sans-serif;
+}
+
+html {
+  font-family: var(--font-sans);
+}

--- a/src/app/home/HomeClient.tsx
+++ b/src/app/home/HomeClient.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { memo, useCallback, useEffect, useState } from "react"
+import { Advocate } from "../types/advocates"
+import { logger } from "@/lib/logger"
+import { API_ADVOCATES } from "../api/advocates/urls"
+import { AdvocatesTable } from "../components/AdvocatesTable"
+import { getApiUrl } from "../api/apiUtils/getApiUrl"
+import { getAdvocates } from "../api/advocates/utils"
+import { useDebounce } from "use-debounce"
+
+const HOME_PAGE_TAG = "Home"
+const DEBOUNCE_INTERVAL = 400
+const MIN_SEARCH_LENGTH = 2
+
+type HomeClientProps = {
+  initialAdvocates: Advocate[]
+}
+
+function HomeClient({ initialAdvocates }: HomeClientProps) {
+  const [advocates, setAdvocates] = useState<Advocate[]>(initialAdvocates)
+  const [searchQuery, setSearchQuery] = useState<string>("")
+  const [debouncedSearchTerm] = useDebounce(searchQuery, DEBOUNCE_INTERVAL)
+
+  const fetchAdvocatesAsync = useCallback(async (query: string = "") => {
+    const advocatesUrl = getApiUrl(API_ADVOCATES, {
+      searchQuery: query,
+      limit: 10,
+      offset: 0,
+    })
+
+    const response = await getAdvocates(advocatesUrl)
+    setAdvocates(response?.data)
+  }, [])
+
+  useEffect(() => {
+    if (debouncedSearchTerm.length >= MIN_SEARCH_LENGTH) {
+      logger({ tag: HOME_PAGE_TAG, message: "fetching filtered advocates..." })
+      fetchAdvocatesAsync(debouncedSearchTerm)
+    }
+  }, [debouncedSearchTerm])
+
+  const onChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setSearchQuery(value)
+    logger({ tag: HOME_PAGE_TAG, message: "user typing..." })
+  }, [])
+
+  const onClick = useCallback(() => {
+    setSearchQuery("")
+    fetchAdvocatesAsync("") // Optional: reset to unfiltered list
+    logger({ tag: HOME_PAGE_TAG, message: "Reset search triggered" })
+  }, [])
+
+  return (
+    <main className="m-6">
+      <h1>Solace Advocates</h1>
+      <br />
+      <br />
+      <div>
+        <p>Search</p>
+        <p>
+          Searching for: <span>{searchQuery}</span>
+        </p>
+        <input className="border border-black" onChange={onChange} />
+        <button onClick={onClick}>Reset Search</button>
+      </div>
+      <br />
+      <br />
+      <AdvocatesTable advocates={advocates} />
+    </main>
+  )
+}
+
+export default memo(HomeClient)

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,99 +1,16 @@
-"use client"
-
-import { useEffect, useState } from "react"
-import { Advocate } from "../types/advocates"
-import { logger } from "@/lib/logger"
 import { API_ADVOCATES } from "../api/advocates/urls"
+import { getAdvocates } from "../api/advocates/utils"
+import { getApiUrl } from "../api/apiUtils/getApiUrl"
+import { Advocate } from "../types/advocates"
+import HomeClient from "./HomeClient"
 
-const HOME_PAGE_TAG = "Home"
+export default async function HomePage() {
+  const initialUrl = getApiUrl(API_ADVOCATES, {
+    limit: 10,
+    offset: 0,
+  })
 
-export default function Home() {
-  const [advocates, setAdvocates] = useState<Advocate[]>([])
-  const [filteredAdvocates, setFilteredAdvocates] = useState<Advocate[]>([])
-  const [searchTerm, setSearchTerm] = useState<string>("")
+  const initialData: Advocate[] = (await getAdvocates(initialUrl))?.data ?? []
 
-  useEffect(() => {
-    logger({ tag: HOME_PAGE_TAG, message: "fetching advocates..." })
-    fetch(API_ADVOCATES).then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data)
-        setFilteredAdvocates(jsonResponse.data)
-      })
-    })
-  }, [])
-
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const searchTerm = e.target.value
-
-    setSearchTerm(searchTerm)
-
-    logger({ tag: HOME_PAGE_TAG, message: "filtering advocates..." })
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.toString().includes(searchTerm)
-      )
-    })
-
-    setFilteredAdvocates(filteredAdvocates)
-  }
-
-  const onClick = () => {
-    logger({ tag: HOME_PAGE_TAG, message: "Advocates data", data: advocates })
-    setFilteredAdvocates(advocates)
-  }
-
-  return (
-    <main className="m-6">
-      <h1>Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
-        <p>Search</p>
-        <p>
-          Searching for: <span>{searchTerm}</span>
-        </p>
-        <input className="border border-black" onChange={onChange} />
-        <button onClick={onClick}>Reset Search</button>
-      </div>
-      <br />
-      <br />
-      <table>
-        <thead>
-          <tr>
-            <th>First Name</th>
-            <th>Last Name</th>
-            <th>City</th>
-            <th>Degree</th>
-            <th>Specialties</th>
-            <th>Years of Experience</th>
-            <th>Phone Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdvocates.map((advocate) => {
-            return (
-              <tr>
-                <td>{advocate.firstName}</td>
-                <td>{advocate.lastName}</td>
-                <td>{advocate.city}</td>
-                <td>{advocate.degree}</td>
-                <td>
-                  {advocate.specialties.map((s) => (
-                    <div>{s}</div>
-                  ))}
-                </td>
-                <td>{advocate.yearsOfExperience}</td>
-                <td>{advocate.phoneNumber}</td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
-    </main>
-  )
+  return <HomeClient initialAdvocates={initialData} />
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
-
-const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "Solace Candidate Assignment",
@@ -16,7 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/src/app/types/advocates.ts
+++ b/src/app/types/advocates.ts
@@ -1,4 +1,5 @@
 export type Advocate = {
+  id: number
   firstName: string
   lastName: string
   city: string
@@ -6,4 +7,5 @@ export type Advocate = {
   specialties: string[]
   yearsOfExperience: number
   phoneNumber: number
+  createdAt: string
 }


### PR DESCRIPTION
This PR reorganizes key parts of the client-side architecture.
- Introduced `query-string` for cleaner and more scalable construction of API URLs
- Adds debounced search to reduce API calls while typing
- Created fetcher utilities for shared API call logic
- Built `getApiUrl` util to standardize query param handling across requests
- Moved `AdvocatesTable` to its own component for better separation of concerns
- Refined font loading: moved `Inter` font to global CSS to prevent layout warnings
- Split SSR and client logic: added `HomeClient` for interactive behavior, SSR for first payload
- Expanded `Advocate` type to include `id` and `createdAt` fields from the backend

These updates improve maintainability to make it easier to build new features (pagination, infinite scroll, filtering).